### PR TITLE
set binmode :utf8

### DIFF
--- a/yaml2json.pl
+++ b/yaml2json.pl
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use feature 'say';
+binmode(STDOUT, ':utf8');
 
 use JSON::PP;
 use YAML::XS;


### PR DESCRIPTION
required for emitting utf8 correctly (and fixes the wide character error).